### PR TITLE
FEATURE: Add a pagination for exceptions

### DIFF
--- a/Classes/Controller/LogsController.php
+++ b/Classes/Controller/LogsController.php
@@ -140,6 +140,10 @@ class LogsController extends AbstractModuleController
 
             $lineCount = preg_match_all('/([\d:\-\s]+)\s([\d]+)(\s+[:.\d]+)?\s+(\w+)\s+(.+)/', $fileContent, $lines);
 
+            for($i = 0; $i <=5; $i++){
+                $lines[$i] = array_reverse($lines[$i]);
+            }
+
             for ($i = 0; $i < $lineCount && count($entries) < $limit; $i++) {
                 $lineLevel = $lines[4][$i];
 

--- a/Classes/Controller/LogsController.php
+++ b/Classes/Controller/LogsController.php
@@ -56,7 +56,7 @@ class LogsController extends AbstractModuleController
     /**
      * Renders the app to interact with the nodetype graph
      */
-    public function indexAction(): void
+    public function indexAction(int $limit = 10): void
     {
         try {
             $logFiles = array_map(function (string $logFile) {
@@ -71,6 +71,9 @@ class LogsController extends AbstractModuleController
         }
 
         try {
+            $exceptionFiles = Files::readDirectoryRecursively($this->exceptionFilesUrl, '.txt');
+            $numberOfExceptions = count($exceptionFiles);
+            rsort($exceptionFiles);
             $exceptionFiles = array_map(function (string $exceptionFile) {
                 $filename = basename($exceptionFile);
                 $date = \DateTime::createFromFormat('YmdHi', substr($filename, 0, 12));
@@ -80,7 +83,7 @@ class LogsController extends AbstractModuleController
                     'date' => $date,
                     'excerpt' => $this->getExcerptFromException(Files::getFileContents($exceptionFile)),
                 ];
-            }, Files::readDirectoryRecursively($this->exceptionFilesUrl, '.txt'));
+            }, array_slice($exceptionFiles, 0, $limit));
         } catch (FilesException $e) {
             $exceptionFiles = [];
         }
@@ -97,6 +100,8 @@ class LogsController extends AbstractModuleController
             'logs' => $logFiles,
             'exceptions' => $exceptionFiles,
             'flashMessages' => $flashMessages,
+            'limit' => $limit,
+            'numberOfExceptions' => $numberOfExceptions
         ]);
     }
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -19,5 +19,10 @@ Neos:
 Shel:
   Neos:
     Logs:
+      pagination:
+        exceptions:
+          pageSize: 20
+        logs:
+          pageSize: 50
       logFilesUrl: '%FLOW_PATH_DATA%Logs'
       exceptionFilesUrl: '%FLOW_PATH_DATA%Logs/Exceptions'

--- a/Resources/Private/Fusion/Views/Index.fusion
+++ b/Resources/Private/Fusion/Views/Index.fusion
@@ -2,6 +2,7 @@ prototype(Shel.Neos.Logs:View.Index) < prototype(Neos.Fusion:Component) {
     logs = ${logs}
     exceptions = ${exceptions}
     flashMessages = ${flashMessages}
+    limit = ${limit}
 
     renderer = afx`
         <style>
@@ -38,8 +39,19 @@ prototype(Shel.Neos.Logs:View.Index) < prototype(Neos.Fusion:Component) {
             <br/>
             <Shel.Neos.Logs:Component.LogList logs={props.logs} />
             <br/>
-            <h2>Exceptions</h2>
+            <h2>{props.limit}/{numberOfExceptions} Exceptions</h2>
             <br/>
+            <form method="POST">
+                <Neos.Fusion:UriBuilder action="index" @path="attributes.action" />
+                <input type="hidden" name="__csrfToken" value={Security.csrfToken()}/>
+                <select name="moduleArguments[limit]" onchange="this.form.submit();" style="margin-left:1rem;">
+                    <option value="10" selected={props.limit == 10}>Show {props.limit} exceptions</option>
+                    <option value="50" selected={props.limit == 50}>Show 50 exceptions</option>
+                    <option value="100" selected={props.limit == 100}>Show 100 exceptions</option>
+                    <option value="300" selected={props.limit == 300}>Show 300 exceptions</option>
+                    <option value="0" selected={props.limit == 0}>Show all exceptions</option>
+                </select>
+            </form>
             <Shel.Neos.Logs:Component.ExceptionList exceptions={props.exceptions} />
         </div>
         <Shel.Neos.Logs:Component.FlashMessages flashMessages={props.flashMessages} />

--- a/Resources/Private/Fusion/Views/Index.fusion
+++ b/Resources/Private/Fusion/Views/Index.fusion
@@ -32,6 +32,15 @@ prototype(Shel.Neos.Logs:View.Index) < prototype(Neos.Fusion:Component) {
             .neos.neos-module table .column__actions a:hover {
                 color: #00b5ff;
             }
+            .neos.neos-module .pagination .neos-button {
+                margin: 0.5rem;
+            }
+            .neos.neos-module .pagination .current {
+                margin: 0.5rem;
+            }
+            .page-selector {
+                display: inline-block;
+            }
             '}
         </style>
         <div id="shel-neos-logs-app">
@@ -39,19 +48,35 @@ prototype(Shel.Neos.Logs:View.Index) < prototype(Neos.Fusion:Component) {
             <br/>
             <Shel.Neos.Logs:Component.LogList logs={props.logs} />
             <br/>
-            <h2>{props.limit}/{numberOfExceptions} Exceptions</h2>
-            <br/>
-            <form method="POST">
-                <Neos.Fusion:UriBuilder action="index" @path="attributes.action" />
-                <input type="hidden" name="__csrfToken" value={Security.csrfToken()}/>
-                <select name="moduleArguments[limit]" onchange="this.form.submit();" style="margin-left:1rem;">
-                    <option value="10" selected={props.limit == 10}>Show {props.limit} exceptions</option>
-                    <option value="50" selected={props.limit == 50}>Show 50 exceptions</option>
-                    <option value="100" selected={props.limit == 100}>Show 100 exceptions</option>
-                    <option value="300" selected={props.limit == 300}>Show 300 exceptions</option>
-                    <option value="0" selected={props.limit == 0}>Show all exceptions</option>
-                </select>
-            </form>
+            <h2>Exceptions ({numberOfExceptions})</h2>
+            <div class="pagination">
+                <Neos.Fusion:Link.Action class="neos-button" href.action="index" href.arguments.exceptionsPage={0}>
+                    |&lt; First
+                </Neos.Fusion:Link.Action>
+                <Neos.Fusion:Link.Action  @if.notFirst={exceptionsPage != 0} class="neos-button" href.action="index" href.arguments.exceptionsPage={exceptionsPage - 1} >
+                    &lt; Previous
+                </Neos.Fusion:Link.Action>
+                <span class="current">
+                    Page {exceptionsPage + 1}
+                </span>
+                <Neos.Fusion:Link.Action @if.notLast={exceptionsPage < numberOfPages} class="neos-button" href.action="index" href.arguments.exceptionsPage={exceptionsPage + 1} >
+                    Next &gt;
+                </Neos.Fusion:Link.Action>
+                <Neos.Fusion:Link.Action class="neos-button" href.action="index" href.arguments.exceptionsPage={numberOfPages} >
+                    Last &gt;|
+                </Neos.Fusion:Link.Action>
+                <form method="POST" class="page-selector">
+                    <Neos.Fusion:UriBuilder action="index" @path="attributes.action" />
+                    <input type="hidden" name="__csrfToken" value={Security.csrfToken()}/>
+                    <select name="moduleArguments[exceptionsPage]" onchange="this.form.submit();" style="margin-left:1rem;">
+                        <option value="">Select page</option>
+                        <Neos.Fusion:Loop items={Array.range(0, numberOfPages)}>
+                            <option value={item}>Go to page {item+1}</option>
+                        </Neos.Fusion:Loop>
+                    </select>
+                </form>
+            </div>
+
             <Shel.Neos.Logs:Component.ExceptionList exceptions={props.exceptions} />
         </div>
         <Shel.Neos.Logs:Component.FlashMessages flashMessages={props.flashMessages} />


### PR DESCRIPTION
If there are many exceptions, it takes quite some time to parse them all, but in the end you still only need the most recent.

Now it only loads the 10 most recent exceptions, but you can rise the limit to load more. 