### PR TITLE
Add prototype Neos.Fusion:Link.Action

### DIFF
--- a/Resources/Private/Fusion/Overrides.fusion
+++ b/Resources/Private/Fusion/Overrides.fusion
@@ -1,0 +1,25 @@
+# Add `Neos.Fusion:Link.Action` prototype for Neos 5.3 compatibility.
+# The prototype is introduced in neos/fusion:7.1
+#
+# Renders a link pointing to a controller/action
+#
+# Usage:
+# link = afx`
+#    <Neos.Fusion:Link.Action class="action-link" href.package="Some.Package" href.controller="Standard" href.action="index">
+#        Some Link
+#    </Neos.Fusion:Link.Action>
+# `
+#
+prototype(Neos.Fusion:Link.Action) < prototype(Neos.Fusion:Component) {
+    href = Neos.Fusion:UriBuilder
+    content = ''
+
+    renderer = Neos.Fusion:Tag {
+        tagName = 'a'
+        attributes {
+            @ignoreProperties = ${['content']}
+            @apply.props = ${props}
+        }
+        content = ${props.content}
+    }
+}


### PR DESCRIPTION
As a simple fix I added the missing prototype. This is only needed when the package is used with neos/neos:5.3.

I am not sure how to handle the duplicated code in projects using `neos/neos:>=7.1`. Does it make sense using a separet branch for `neos/neos:~5.3`.

#19 