### PR TITLE
BUGFIX: fix show and download for logs in subdirectories

### DIFF
--- a/Classes/Controller/LogsController.php
+++ b/Classes/Controller/LogsController.php
@@ -83,7 +83,7 @@ class LogsController extends AbstractModuleController
 
     public function showLogfileAction(): void
     {
-        ['filename' => $filename] = $this->request->getArguments();
+        ['filename' => $filename, 'filepath' => $filepath] = $this->request->getArguments();
 
         $entries = [];
         $levels = [];
@@ -91,7 +91,7 @@ class LogsController extends AbstractModuleController
         $level = $this->request->hasArgument('level') ? $this->request->getArgument('level') : '';
         $limit = $this->request->hasArgument('limit') ? $this->request->getArgument('limit') : 50;
 
-        $fileContent = $this->logsService->getLogFileContents($filename);
+        $fileContent = $this->logsService->getLogFileContents($filepath);
         if ($fileContent) {
             $lineCount = preg_match_all('/([\d:\-\s]+)\s([\d]+)(\s+[:.\d]+)?\s+(\w+)\s+(.+)/', $fileContent, $lines);
 
@@ -135,11 +135,11 @@ class LogsController extends AbstractModuleController
      */
     public function downloadLogfileAction(): void
     {
-        ['filename' => $filename] = $this->request->getArguments();
+        ['filename' => $filename, 'filepath' => $filepath] = $this->request->getArguments();
 
-        $filepath = $this->logsService->getValidLogFilepath($filename);
-        if ($filepath) {
-            $this->startFileDownload($filepath, $filename);
+        $validFilepath = $this->logsService->getValidLogFilepath($filepath);
+        if ($validFilepath) {
+            $this->startFileDownload($validFilepath, $filename);
         } else {
             $this->addFlashMessage(sprintf('Logfile %s not found', $filename), Message::SEVERITY_ERROR);
         }

--- a/Classes/Controller/LogsController.php
+++ b/Classes/Controller/LogsController.php
@@ -83,7 +83,7 @@ class LogsController extends AbstractModuleController
 
     public function showLogfileAction(): void
     {
-        ['filename' => $filename, 'filepath' => $filepath] = $this->request->getArguments();
+        ['relativeFilepath' => $relativeFilepath] = $this->request->getArguments();
 
         $entries = [];
         $levels = [];
@@ -91,7 +91,7 @@ class LogsController extends AbstractModuleController
         $level = $this->request->hasArgument('level') ? $this->request->getArgument('level') : '';
         $limit = $this->request->hasArgument('limit') ? $this->request->getArgument('limit') : 50;
 
-        $fileContent = $this->logsService->getLogFileContents($filepath);
+        $fileContent = $this->logsService->getLogFileContents($relativeFilepath);
         if ($fileContent) {
             $lineCount = preg_match_all('/([\d:\-\s]+)\s([\d]+)(\s+[:.\d]+)?\s+(\w+)\s+(.+)/', $fileContent, $lines);
 
@@ -119,8 +119,9 @@ class LogsController extends AbstractModuleController
             $this->addFlashMessage('Logfile could not be read', Message::SEVERITY_ERROR);
         }
 
+        $filepath = $this->logsService->getValidLogFilepath($relativeFilepath);
         $this->view->assignMultiple([
-            'filename' => $filename,
+            'filename' => basename($filepath),
             'entries' => $entries,
             'flashMessages' => $this->controllerContext->getFlashMessageContainer()->getMessagesAndFlush(),
             'levels' => array_keys($levels),
@@ -135,9 +136,10 @@ class LogsController extends AbstractModuleController
      */
     public function downloadLogfileAction(): void
     {
-        ['filename' => $filename, 'filepath' => $filepath] = $this->request->getArguments();
+        ['relativeFilepath' => $filepath] = $this->request->getArguments();
 
         $validFilepath = $this->logsService->getValidLogFilepath($filepath);
+        $filename = basename($validFilepath, '.log');
         if ($validFilepath) {
             $this->startFileDownload($validFilepath, $filename);
         } else {

--- a/Classes/Service/LogsService.php
+++ b/Classes/Service/LogsService.php
@@ -39,15 +39,17 @@ class LogsService
      */
     public function getLogFiles(): array
     {
+        $logFilesPath = $this->logFilesUrl;
+
         // Retrieve all log files (there shouldn't be more than 10 in 99% of projects)
         try {
-            return array_map(function (string $logFile) {
+            return array_map(static function (string $logFile) use ($logFilesPath) {
                 $filePathInfo = pathinfo($logFile);
                 return [
                     'filename' => basename($logFile),
                     'label' => $filePathInfo['filename'],
                     'extension' => $filePathInfo['extension'],
-                    'relativePath' => substr($logFile, strlen($this->logFilesUrl)),
+                    'relativePath' => Files::getRelativePath($logFilesPath, $logFile),
                 ];
             }, Files::readDirectoryRecursively($this->logFilesUrl, '.log'));
         } catch (\Exception $e) {

--- a/Classes/Service/LogsService.php
+++ b/Classes/Service/LogsService.php
@@ -35,17 +35,16 @@ class LogsService
 
     /**
      * TODO: Introduce DTO for log files
-     * @return array{name: string, identifier: string}[]
+     * @return array{identifier: string, path: string}[]
      */
     public function getLogFiles(): array
     {
         // Retrieve all log files (there shouldn't be more than 10 in 99% of projects)
         try {
             return array_map(static function (string $logFile) {
-                $filename = basename($logFile);
                 return [
-                    'name' => basename($logFile),
-                    'identifier' => $filename,
+                    'identifier' => basename($logFile),
+                    'path' => $logFile,
                 ];
             }, Files::readDirectoryRecursively($this->logFilesUrl, '.log'));
         } catch (\Exception $e) {
@@ -120,10 +119,9 @@ class LogsService
         return $deduplicatedExceptions;
     }
 
-    public function getLogFileContents($filename): ?string
+    public function getLogFileContents(string $filepath): ?string
     {
-        $filepath = self::getFilepath($this->logFilesUrl, $filename);
-        if ($filename && self::isFilenameValid($this->logFilesUrl, $filepath)) {
+        if (self::isFilenameValid($this->logFilesUrl, $filepath)) {
             return Files::getFileContents($filepath);
         }
         return null;
@@ -143,10 +141,9 @@ class LogsService
         return null;
     }
 
-    public function getValidLogFilepath(string $filename): ?string
+    public function getValidLogFilepath(string $filepath): ?string
     {
-        $filepath = self::getFilepath($this->logFilesUrl, $filename);
-        if ($filename && self::isFilenameValid($this->logFilesUrl, $filepath)) {
+        if (self::isFilenameValid($this->logFilesUrl, $filepath)) {
             return $filepath;
         }
         return null;
@@ -159,7 +156,7 @@ class LogsService
     {
         $content = htmlspecialchars($fileContent, ENT_QUOTES | ENT_HTML5);
         preg_match('/^(?s)(.*?)(?:\R{2,}|$)(.*)/', $content, $matches);
-        $excerpt = str_replace(FLOW_PATH_ROOT, '…/', $matches[1] ?? '');;
+        $excerpt = str_replace(FLOW_PATH_ROOT, '…/', $matches[1] ?? '');
         $stacktrace = str_replace(FLOW_PATH_ROOT, '…/', $matches[2] ?? '');
 
         return [

--- a/Classes/Service/LogsService.php
+++ b/Classes/Service/LogsService.php
@@ -41,10 +41,13 @@ class LogsService
     {
         // Retrieve all log files (there shouldn't be more than 10 in 99% of projects)
         try {
-            return array_map(static function (string $logFile) {
+            return array_map(function (string $logFile) {
+                $filePathInfo = pathinfo($logFile);
                 return [
-                    'identifier' => basename($logFile),
-                    'path' => $logFile,
+                    'filename' => basename($logFile),
+                    'label' => $filePathInfo['filename'],
+                    'extension' => $filePathInfo['extension'],
+                    'relativePath' => substr($logFile, strlen($this->logFilesUrl)),
                 ];
             }, Files::readDirectoryRecursively($this->logFilesUrl, '.log'));
         } catch (\Exception $e) {
@@ -119,8 +122,9 @@ class LogsService
         return $deduplicatedExceptions;
     }
 
-    public function getLogFileContents(string $filepath): ?string
+    public function getLogFileContents(string $relativeFilepath): ?string
     {
+        $filepath = self::getFilepath($this->logFilesUrl, trim($relativeFilepath, '/'));
         if (self::isFilenameValid($this->logFilesUrl, $filepath)) {
             return Files::getFileContents($filepath);
         }
@@ -141,9 +145,10 @@ class LogsService
         return null;
     }
 
-    public function getValidLogFilepath(string $filepath): ?string
+    public function getValidLogFilepath(string $relativeFilepath): ?string
     {
-        if (self::isFilenameValid($this->logFilesUrl, $filepath)) {
+        $filepath = self::getFilepath($this->logFilesUrl, trim($relativeFilepath, '/'));
+        if ($relativeFilepath && self::isFilenameValid($this->logFilesUrl, $filepath)) {
             return $filepath;
         }
         return null;

--- a/Resources/Private/Fusion/Components/LogList.fusion
+++ b/Resources/Private/Fusion/Components/LogList.fusion
@@ -17,9 +17,9 @@ prototype(Shel.Neos.Logs:Component.LogList) < prototype(Neos.Fusion:Component) {
                                 <Neos.Fusion:UriBuilder
                                     @path="attributes.href"
                                     action="showLogfile"
-                                    arguments={{'filename': file.identifier}}
+                                    arguments={{'filename': file.identifier, 'filepath': file.path}}
                                 />
-                                {file.name}
+                                {file.identifier}
                             </a>
                         </td>
                         <td class="column__actions">
@@ -27,7 +27,7 @@ prototype(Shel.Neos.Logs:Component.LogList) < prototype(Neos.Fusion:Component) {
                                 <Neos.Fusion:UriBuilder
                                     @path="attributes.href"
                                     action="downloadLogfile"
-                                    arguments={{'filename': file.identifier}}
+                                    arguments={{'filename': file.identifier, 'filepath': file.path}}
                                 />
                                 <i class="fas fa-download"></i>
                             </a>

--- a/Resources/Private/Fusion/Components/LogList.fusion
+++ b/Resources/Private/Fusion/Components/LogList.fusion
@@ -17,9 +17,9 @@ prototype(Shel.Neos.Logs:Component.LogList) < prototype(Neos.Fusion:Component) {
                                 <Neos.Fusion:UriBuilder
                                     @path="attributes.href"
                                     action="showLogfile"
-                                    arguments={{'filename': file.identifier, 'filepath': file.path}}
+                                    arguments={{'relativeFilepath': file.relativePath}}
                                 />
-                                {file.identifier}
+                                {file.label}
                             </a>
                         </td>
                         <td class="column__actions">
@@ -27,7 +27,7 @@ prototype(Shel.Neos.Logs:Component.LogList) < prototype(Neos.Fusion:Component) {
                                 <Neos.Fusion:UriBuilder
                                     @path="attributes.href"
                                     action="downloadLogfile"
-                                    arguments={{'filename': file.identifier, 'filepath': file.path}}
+                                    arguments={{'relativeFilepath': file.relativePath}}
                                 />
                                 <i class="fas fa-download"></i>
                             </a>


### PR DESCRIPTION
**Context:**
If custom log files are created in subdirectories of the log directory, the `showLogfileAction()` and `downloadLogfileAction()` will crash. This happens, because `getLogFiles()` only returns the file name and later the path is reassembled using the configured `$logFilesUrl`, therefore losing any subdirectories.

**Changes:**
- use original filepath instead of creating filepath from file name and logs directory
- remove name from `getLogFiles()` return, because it's the same as identifier
- add path to return form `getLogFiles()`
- use `file.identifier` for displaying the file name in fusion