### PR TITLE
BUGFIX: Update showExceptionCommand to allow null identifier

### DIFF
--- a/Classes/Command/LogsCommandController.php
+++ b/Classes/Command/LogsCommandController.php
@@ -44,7 +44,7 @@ class LogsCommandController extends CommandController
         );
     }
 
-    public function showExceptionCommand(string $identifier = null): void
+    public function showExceptionCommand(?string $identifier = null): void
     {
         // If no identifier is provided, try to get it from the arguments
         if (!$identifier) {


### PR DESCRIPTION
Removes deprecated notice if PHP 8.4 is used